### PR TITLE
CVE-2018-15560 - update pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_packages(package):
 
 
 def get_install_requires():
-    crypto_lib = 'pycryptodome >=3.3.1, <3.4.0'
+    crypto_lib = 'pycryptodome >=3.3.1, <3.7.1'
     return [
         crypto_lib,
         'six <2.0',


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-15560
PyCryptodome before 3.6.6 has an integer overflow in the data_len variable in AESNI.c, related to the AESNI_encrypt and AESNI_decrypt functions, leading to the mishandling of messages shorter than 16 bytes.

<img width="776" alt="screen shot 2019-01-22 at 6 38 37 pm" src="https://user-images.githubusercontent.com/128533/51579210-f7909c80-1e74-11e9-90db-46735d790aed.png">
