### PR TITLE
Import ABC from collections.abc instead of collections for Python 3 compatibility

### DIFF
--- a/jose/jws.py
+++ b/jose/jws.py
@@ -3,7 +3,10 @@ import binascii
 import json
 import six
 
-from collections import Mapping, Iterable
+try:
+    from collections.abc import Mapping, Iterable
+except ImportError:
+    from collections import Mapping, Iterable
 
 from jose import jwk
 from jose.constants import ALGORITHMS

--- a/jose/jwt.py
+++ b/jose/jwt.py
@@ -3,10 +3,14 @@ import binascii
 import json
 
 from calendar import timegm
-from collections import Mapping
 from datetime import datetime
 from datetime import timedelta
 from six import string_types
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 from jose import jws
 


### PR DESCRIPTION
Fixes #10 