### PR TITLE
Allow minor version upgrades for pycryptodome

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_packages(package):
 
 
 def get_install_requires():
-    crypto_lib = 'pycryptodome >=3.3.1, <3.4.0'
+    crypto_lib = 'pycryptodome >=3.3.1, <4.0.0'
     return [
         crypto_lib,
         'six <2.0',


### PR DESCRIPTION
[python-jose](https://github.com/mpdavis/python-jose/blob/master/setup.py#L39) also allow minor version upgrades. This also fixes incompatible dependencies between packages. Thanks!